### PR TITLE
TimeOfDay support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ go get -u github.com/jgpruitt/config
     * *url.URL
     * file path
     * net.IP
+	* time of day (as `hour, minute int`)
 * Easily substitute defaults for missing keys or incorrectly specified values
 * Heavily unit tested
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/jgpruitt/config
+
+go 1.20


### PR DESCRIPTION
* Adds go module support
* Adds old TimeOfDay & default from other respository
* Corrects yoda condition linting error
* Adds new tests for TimeOfDay & default functions

(formatting changes may be from newer version of go fmt) Tested with go version 1.20.6